### PR TITLE
Follow up Android edge-to-edge padding fixes

### DIFF
--- a/src/components/LabelEditor.tsx
+++ b/src/components/LabelEditor.tsx
@@ -5,7 +5,7 @@ import {StackParamList} from "@app/navigation/navigationParams"
 import {useNavigation} from "@react-navigation/native"
 import {NativeStackNavigationProp} from "@react-navigation/native-stack"
 import {useState} from "react"
-import {StyleSheet, TouchableOpacity, View} from "react-native"
+import {Platform, StyleSheet, TouchableOpacity, View} from "react-native"
 import {
   NestableDraggableFlatList,
   NestableScrollContainer,
@@ -14,6 +14,7 @@ import {
 import {Button, Dialog, IconButton, Text, TextInput} from "react-native-paper"
 import {useTheme} from "react-native-paper/src/core/theming"
 import Animated, {FadeIn, FadeOut} from "react-native-reanimated"
+import {useSafeAreaInsets} from "react-native-safe-area-context"
 
 const ITEM_HEIGHT = 60
 
@@ -29,6 +30,7 @@ export default function LabelEditor() {
   const navigation = useNavigation<NativeStackNavigationProp<StackParamList>>()
   const dispatch = useAppDispatch()
   const theme = useTheme()
+  const insets = useSafeAreaInsets()
 
   // start editing
   const startEditing = (label: string) => {
@@ -124,8 +126,13 @@ export default function LabelEditor() {
     )
   }
 
+  const containerStyle = {...styles.container}
+  if (Platform.OS === "android") {
+    containerStyle.paddingBottom += insets.bottom
+  }
+
   return (
-    <View style={styles.container}>
+    <View style={containerStyle}>
       <NestableScrollContainer keyboardShouldPersistTaps="handled">
         <NestableDraggableFlatList
           keyboardShouldPersistTaps="handled"
@@ -175,7 +182,11 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "space-between",
     height: "100%",
-    padding: 7,
+    // Keeping separate so we can change the bottom padding
+    paddingTop: 7,
+    paddingRight: 7,
+    paddingBottom: 7,
+    paddingLeft: 7,
   },
   header: {
     height: 35,

--- a/src/components/TagLabels.tsx
+++ b/src/components/TagLabels.tsx
@@ -6,8 +6,9 @@ import {TagListType} from "@app/modules/tagLists"
 import {StackParamList} from "@app/navigation/navigationParams"
 import {useNavigation} from "@react-navigation/native"
 import {NativeStackNavigationProp} from "@react-navigation/native-stack"
-import {ScrollView, StyleSheet, View} from "react-native"
+import {Platform, ScrollView, StyleSheet, View} from "react-native"
 import {Button, Checkbox, useTheme} from "react-native-paper"
+import {useSafeAreaInsets} from "react-native-safe-area-context"
 
 const LabelSelector = (props: {
   tag: Tag
@@ -46,6 +47,7 @@ const TagLabels = () => {
     state => state.favorites.labelsByTagId[tag.id],
   )
   const theme = useTheme()
+  const insets = useSafeAreaInsets()
 
   const themedStyles = StyleSheet.create({
     container: {
@@ -53,6 +55,7 @@ const TagLabels = () => {
       margin: 10,
       borderRadius: 15,
       justifyContent: "space-between",
+      paddingBottom: Platform.OS === "android" ? insets.bottom : 0,
     },
     divider: {
       marginTop: 10,

--- a/src/navigation/StackNavigator.tsx
+++ b/src/navigation/StackNavigator.tsx
@@ -17,6 +17,7 @@ import {
 } from "@react-navigation/native-stack"
 import {HeaderBackButtonProps} from "@react-navigation/native-stack/lib/typescript/src/types"
 import {useMemo} from "react"
+import {Platform} from "react-native"
 import {Provider as PaperProvider, Text} from "react-native-paper"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
 import Icon from "react-native-vector-icons/MaterialCommunityIcons"
@@ -36,17 +37,31 @@ const BACK_ICON_SIZE = 36
 
 const BackButton = (_props: HeaderBackButtonProps) => {
   const navigation = useNavigation()
+  const insets = useSafeAreaInsets()
+
+  const style = {paddingLeft: Platform.OS === "android" ? insets.left : 0}
+
   return (
-    <Icon name={BACK_ICON} size={BACK_ICON_SIZE} onPress={navigation.goBack} />
+    <Icon
+      name={BACK_ICON}
+      size={BACK_ICON_SIZE}
+      style={style}
+      onPress={navigation.goBack}
+    />
   )
 }
 
 const BackToDrawerClose = (_props: HeaderBackButtonProps) => {
   const navigation = useNavigation()
+  const insets = useSafeAreaInsets()
+
+  const style = {paddingLeft: Platform.OS === "android" ? insets.left : 0}
+
   return (
     <Icon
       name={BACK_ICON}
       size={BACK_ICON_SIZE}
+      style={style}
       onPress={() => {
         navigation.dispatch(DrawerActions.closeDrawer())
         navigation.goBack()


### PR DESCRIPTION
This fixes a few places not noticed in #3, namely in the screens accessible via the drawer when using 3-button nav. It gives the up buttons left padding and ensures the new label button is above the nav bar.

| **Before** | **After** |
| - | - |
| ![Screenshot_20240212-111020](https://github.com/kamatsuoka/goodtags/assets/463696/f60fac7d-cdf9-459f-b331-9c6900629963) | ![Screenshot_20240212-111040](https://github.com/kamatsuoka/goodtags/assets/463696/68f10b83-728a-4908-88ac-3fe855a5474f) |
| ![Screenshot_20240212-111010](https://github.com/kamatsuoka/goodtags/assets/463696/16266671-a567-47ae-a9f2-d1245c3733ba) | ![Screenshot_20240212-111033](https://github.com/kamatsuoka/goodtags/assets/463696/238f6e86-0ffd-42ff-9786-8e2c6a05bfb9) |