### PR TITLE
[Offline search] Ensure the up-to-date database is available in the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ web-build/
 
 # Generating offline search DB
 /out/
+/src/assets/generated_db/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ web-build/
 # Generating offline search DB
 /out/
 /src/assets/generated_db/
+
+# vscode settings
+.vscode/
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,3 @@ android/
 ios/
 keystores/
 patches/
-scripts/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
@@ -75,6 +77,22 @@ def printPassword = tasks.register("printPassword") {
     doLast {
         println "printing password ..."
         println uploadKeyPassword
+    }
+}
+
+def downloadSearchDatabase = tasks.register("downloadSearchDatabase", Exec) {
+    // Check taken from https://stackoverflow.com/a/12784930/3000133
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine "cmd", "/c", "yarn run download-search-db"
+    } else {
+        commandLine "yarn", "run", "download-search-db"
+
+    }
+}
+
+afterEvaluate {
+    tasks.named("createBundleReleaseJsAndAssets").configure {
+        dependsOn downloadSearchDatabase
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * @format
  */
 
+import {warmupDb} from "@app/modules/sqlUtil"
 import {AppRegistry} from "react-native"
 import "react-native-gesture-handler"
 import {
@@ -37,3 +38,6 @@ setUnhandledPromiseRejectionTracker((id, error) => {
   }
 })
 AppRegistry.registerComponent(appName, () => App)
+
+// Kickoff setting up the DB, including potentially downloading an updated DB, at app startup.
+warmupDb()

--- a/ios/goodtags.xcodeproj/project.pbxproj
+++ b/ios/goodtags.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "yarn run download-search-db";
+			shellScript = "PATH=\"$PATH:/opt/homebrew/bin\" yarn run download-search-db\n";
 			showEnvVarsInLog = 0;
 		};
 		743A12DB8A85CC8909793C41 /* [CP] Check Pods Manifest.lock */ = {

--- a/ios/goodtags.xcodeproj/project.pbxproj
+++ b/ios/goodtags.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "goodtags" */;
 			buildPhases = (
 				743A12DB8A85CC8909793C41 /* [CP] Check Pods Manifest.lock */,
+				368F4735A18E08EAEB68A451 /* Download Search DB */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				9B866312F6A68A0CE51D2DB4 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
@@ -539,6 +540,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		368F4735A18E08EAEB68A451 /* Download Search DB */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Download Search DB";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "yarn run download-search-db";
 			showEnvVarsInLog = 0;
 		};
 		743A12DB8A85CC8909793C41 /* [CP] Check Pods Manifest.lock */ = {

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,4 +8,9 @@ const {getDefaultConfig, mergeConfig} = require("@react-native/metro-config")
  */
 const config = {}
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config)
+let defaultConfig = getDefaultConfig(__dirname)
+
+// Can't use the mergeConfig mechanism below because it doesn't merge lists, it just replaces them.
+defaultConfig.resolver.assetExts.push("sqlite")
+
+module.exports = mergeConfig(defaultConfig, config)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "clean": "react-native-clean-project",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "download-search-db": "ts-node ./scripts/downloadLatestSearchDb.ts",
+    "preandroid": "yarn run download-search-db",
+    "preios": "yarn run download-search-db",
+    "prestart": "yarn run download-search-db"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.18.2",
@@ -27,7 +31,10 @@
     "@shopify/flash-list": "^1.6.3",
     "axios": "^1.6.2",
     "expo": "^49.0.0",
+    "expo-asset": "~8.10.1",
+    "expo-file-system": "~15.4.5",
     "expo-haptics": "~12.4.0",
+    "expo-sqlite": "~11.3.3",
     "fast-xml-parser": "^4.0.12",
     "html-entities": "^2.3.3",
     "lodash": "^4.17.21",
@@ -97,6 +104,7 @@
     "react-native-gradle-plugin": "^0.71.19",
     "react-test-renderer": "^18.2.0",
     "redux-mock-store": "^1.5.4",
+    "ts-node": "^10.9.2",
     "typescript": "^5.1.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/color": "^3.0.3",
     "@types/jest": "^26.0.23",
     "@types/lodash": "^4.14.189",
-    "@types/node": "^18.11.9",
+    "@types/node": "^20.12.7",
     "@types/react": "^18.0.24",
     "@types/react-native-vector-icons": "^6.4.12",
     "@types/react-test-renderer": "^18.0.0",
@@ -108,7 +108,7 @@
     "typescript": "^5.1.3"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "jest": {
     "preset": "jest-expo",

--- a/scripts/downloadLatestSearchDb.ts
+++ b/scripts/downloadLatestSearchDb.ts
@@ -1,0 +1,112 @@
+import * as fs from "fs"
+import http from "node:http"
+import https from "node:https"
+import path from "node:path"
+import process from "node:process"
+
+const ASSETS_URL_PREFIX = "https://kamatsuoka.github.io/goodtags"
+
+const OUT_DIR = path.join(__dirname, "../src/assets/generated_db")
+const MANIFEST_PATH = path.join(OUT_DIR, "manifest.json")
+const SQL_NAME_REMOTE = "tags_db.sqlite.otf"
+const SQL_NAME_LOCAL = path.join(OUT_DIR, "tags_db.sqlite")
+
+async function downloadLatestSearchDb() {
+  try {
+    const manifestContents = await fetchRemoteManifest()
+    // TODO - Should we put the DB md5sum in the manifest and use that to validate the DB (for both checking
+    //  existing and downloading new)?
+    if (shouldDownload(manifestContents)) {
+      console.log("Downloading latest database...")
+      await downloadDb(manifestContents)
+    }
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+/**
+ * Downloads the current manifest and returns its contents
+ */
+async function fetchRemoteManifest(): Promise<Uint8Array> {
+  // What an ugly API; If we require Node >= 18 we can just use the new `fetch` API
+  return await new Promise((resolve, reject) => {
+    const req = https.get(
+      `${ASSETS_URL_PREFIX}/${path.basename(MANIFEST_PATH)}`,
+      (res: http.IncomingMessage) => {
+        let chunks: Uint8Array[] = []
+        res.on("data", (chunk: Uint8Array) => chunks.push(chunk))
+        res.on("error", reject)
+        res.on("end", () => {
+          const body = Buffer.concat(chunks)
+          if (
+            res.statusCode != null &&
+            res.statusCode >= 200 &&
+            res.statusCode <= 299
+          ) {
+            resolve(body)
+          } else {
+            reject(
+              "Request failed. status: " + res.statusCode + ", body: " + body,
+            )
+          }
+        })
+      },
+    )
+    req.on("error", reject)
+    req.end()
+  })
+}
+
+/**
+ * Checks whether we should download the full database and write out both the manifest and database to disk.
+ *
+ * Specifically compares the downloaded manifest contents against what's on disk (if anything), and also looks
+ * to see if the database file exists.
+ */
+function shouldDownload(latestManifestContents: Uint8Array): boolean {
+  const existingManifestContents = fs.existsSync(MANIFEST_PATH)
+    ? fs.readFileSync(MANIFEST_PATH)
+    : Buffer.from([])
+  const manifestsDiffer = !existingManifestContents.equals(
+    latestManifestContents,
+  )
+  const dbMissing = !fs.existsSync(SQL_NAME_LOCAL)
+  return manifestsDiffer || dbMissing
+}
+
+/**
+ * Downloads the DB and writes both the manifest and DB to disk
+ */
+async function downloadDb(latestManifestContents: Uint8Array) {
+  fs.mkdirSync(OUT_DIR, {recursive: true})
+  fs.writeFileSync(MANIFEST_PATH, latestManifestContents)
+
+  return new Promise((resolve, reject) => {
+    const req = https.get(
+      `${ASSETS_URL_PREFIX}/${SQL_NAME_REMOTE}`,
+      (res: http.IncomingMessage) => {
+        const dbFile = fs.openSync(SQL_NAME_LOCAL, "w")
+        res.on("data", (chunk: Uint8Array) => fs.writeSync(dbFile, chunk))
+        res.on("error", reject)
+        res.on("end", () => {
+          fs.closeSync(dbFile)
+          if (
+            res.statusCode != null &&
+            res.statusCode >= 200 &&
+            res.statusCode <= 299
+          ) {
+            resolve(null)
+          } else {
+            reject("Request failed. status: " + res.statusCode)
+          }
+        })
+      },
+    )
+    req.on("error", reject)
+    req.end()
+  })
+}
+
+downloadLatestSearchDb()

--- a/src/modules/__tests__/sqlUtil.test.ts
+++ b/src/modules/__tests__/sqlUtil.test.ts
@@ -47,14 +47,14 @@ describe("DbWrapper class", () => {
       const db2 = new TestSqliteDatabase()
       const wrapper = new DbWrapper(db1)
 
-      await wrapper.transactionAsync(async _ => {}, true)
+      await wrapper.runTransactionAsync(async _ => {}, true)
       expect(db1.numTxns).toBe(1)
       expect(db2.numTxns).toBe(0)
 
       await wrapper.queueDbReplacement(async () => db2)
       await settle()
 
-      await wrapper.transactionAsync(async _ => {}, true)
+      await wrapper.runTransactionAsync(async _ => {}, true)
       expect(db1.numTxns).toBe(1)
       expect(db2.numTxns).toBe(1)
     })
@@ -64,8 +64,8 @@ describe("DbWrapper class", () => {
       const wrapper = new DbWrapper(db)
 
       const {promise, resolve} = promiseWithResolvers<void>()
-      const t1 = wrapper.transactionAsync(async _ => await promise, true)
-      const t2 = wrapper.transactionAsync(async _ => await promise, true)
+      const t1 = wrapper.runTransactionAsync(async _ => await promise, true)
+      const t2 = wrapper.runTransactionAsync(async _ => await promise, true)
 
       let hasDoneReplacement = false
       await wrapper.queueDbReplacement(async () => {
@@ -92,8 +92,8 @@ describe("DbWrapper class", () => {
         await promise
         return db
       })
-      const t1 = wrapper.transactionAsync(async _ => {}, true)
-      const t2 = wrapper.transactionAsync(async _ => {}, true)
+      const t1 = wrapper.runTransactionAsync(async _ => {}, true)
+      const t2 = wrapper.runTransactionAsync(async _ => {}, true)
       await settle()
 
       expect(db.numTxns).toBe(0)
@@ -109,7 +109,7 @@ describe("DbWrapper class", () => {
 
       // Prevent replacement from starting by having an ongoing txn
       const {promise, resolve} = promiseWithResolvers<void>()
-      const t = wrapper.transactionAsync(async _ => await promise, true)
+      const t = wrapper.runTransactionAsync(async _ => await promise, true)
       // Submit the two replacements
       let replacedA = false
       let replacedB = false

--- a/src/modules/__tests__/sqlUtil.test.ts
+++ b/src/modules/__tests__/sqlUtil.test.ts
@@ -1,0 +1,165 @@
+import {DbWrapper, InnerDb} from "@app/modules/sqlUtil"
+import {setImmediate} from "@testing-library/react-native/build/helpers/timers"
+import {SQLTransactionAsync, SQLTransactionAsyncCallback} from "expo-sqlite"
+
+class TestSqliteDatabase implements InnerDb {
+  numTxns: number
+
+  constructor() {
+    this.numTxns = 0
+  }
+
+  async transactionAsync(
+    callback: SQLTransactionAsyncCallback,
+    _readOnly: boolean = false,
+  ) {
+    this.numTxns += 1
+    // Absolutely a hack, it's assumed the txn is never used in tests
+    await callback({} as SQLTransactionAsync)
+  }
+
+  closeAsync() {}
+}
+
+/** Wait a little bit for promises to reach a steady state */
+async function settle() {
+  await new Promise(setImmediate)
+}
+
+// Implementation of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
+function promiseWithResolvers<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: any) => void
+} {
+  let resolve, reject
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return {promise, resolve: resolve as any, reject: reject as any}
+}
+
+describe("DbWrapper class", () => {
+  describe("replacing the underlying DB", () => {
+    it("should direct new transactions to the new DB", async () => {
+      const db1 = new TestSqliteDatabase()
+      const db2 = new TestSqliteDatabase()
+      const wrapper = new DbWrapper(db1)
+
+      await wrapper.transactionAsync(async _ => {}, true)
+      expect(db1.numTxns).toBe(1)
+      expect(db2.numTxns).toBe(0)
+
+      await wrapper.queueDbReplacement(async () => db2)
+      await settle()
+
+      await wrapper.transactionAsync(async _ => {}, true)
+      expect(db1.numTxns).toBe(1)
+      expect(db2.numTxns).toBe(1)
+    })
+
+    it("should wait until the last ongoing transaction finishes", async () => {
+      const db = new TestSqliteDatabase()
+      const wrapper = new DbWrapper(db)
+
+      const {promise, resolve} = promiseWithResolvers<void>()
+      const t1 = wrapper.transactionAsync(async _ => await promise, true)
+      const t2 = wrapper.transactionAsync(async _ => await promise, true)
+
+      let hasDoneReplacement = false
+      await wrapper.queueDbReplacement(async () => {
+        hasDoneReplacement = true
+        return db
+      })
+      await settle()
+
+      expect(hasDoneReplacement).toBe(false)
+
+      resolve()
+      await Promise.all([t1, t2])
+      await settle()
+
+      expect(hasDoneReplacement).toBe(true)
+    })
+
+    it("should queue up subsequent transactions while a replacement is ongoing", async () => {
+      const db = new TestSqliteDatabase()
+      const wrapper = new DbWrapper(db)
+
+      const {promise, resolve} = promiseWithResolvers<void>()
+      await wrapper.queueDbReplacement(async () => {
+        await promise
+        return db
+      })
+      const t1 = wrapper.transactionAsync(async _ => {}, true)
+      const t2 = wrapper.transactionAsync(async _ => {}, true)
+      await settle()
+
+      expect(db.numTxns).toBe(0)
+
+      resolve()
+      await Promise.all([t1, t2])
+      expect(db.numTxns).toBe(2)
+    })
+
+    it("should ignore second replacement if first hasn't started yet", async () => {
+      const db = new TestSqliteDatabase()
+      const wrapper = new DbWrapper(db)
+
+      // Prevent replacement from starting by having an ongoing txn
+      const {promise, resolve} = promiseWithResolvers<void>()
+      const t = wrapper.transactionAsync(async _ => await promise, true)
+      // Submit the two replacements
+      let replacedA = false
+      let replacedB = false
+      await wrapper.queueDbReplacement(async () => {
+        replacedA = true
+        return db
+      })
+      await wrapper.queueDbReplacement(async () => {
+        replacedB = true
+        return db
+      })
+      // Resolve the txn so the replacement can happen
+      resolve()
+      await t
+      await settle()
+
+      expect(replacedA).toBe(true)
+      expect(replacedB).toBe(false)
+    })
+
+    it("should queue second replacement if first has already started", async () => {
+      const db = new TestSqliteDatabase()
+      const wrapper = new DbWrapper(db)
+
+      // Prevent replacement from finishing
+      const {promise, resolve} = promiseWithResolvers<void>()
+      let replacedA = false
+      let replacedB = false
+      await wrapper.queueDbReplacement(async () => {
+        replacedA = true
+        await promise
+        return db
+      })
+      await settle()
+
+      expect(replacedA).toBe(true)
+
+      // Queue the second replacement
+      const q = wrapper.queueDbReplacement(async () => {
+        replacedB = true
+        return db
+      })
+      await settle()
+
+      // Finishing the ongoing replacement
+      resolve()
+      await q
+      await settle()
+
+      expect(replacedB).toBe(true)
+    })
+  })
+})

--- a/src/modules/getUrl.e2e.ts
+++ b/src/modules/getUrl.e2e.ts
@@ -1,25 +1,23 @@
 import {PopularQueryParams} from "@app/modules/popularSlice"
-import {QueryParams} from "../constants/Search"
+import {AxiosRequestConfig} from "axios"
 import {popularXml} from "./__mocks__/popular.xml"
 
 /**
  * Mock for detox end-to-end testing
  */
-export default async function getUrl(
+export default async function getUrl<T = string>(
   baseUrl: string,
-  queryParams: QueryParams,
-): Promise<string> {
+  config?: AxiosRequestConfig<any>,
+): Promise<T> {
   console.debug(
-    `getUrl.e2e: baseUrl=${baseUrl}, queryParams = ${JSON.stringify(
-      queryParams,
-    )}`,
+    `getUrl.e2e: baseUrl=${baseUrl}, config = ${JSON.stringify(config)}`,
   )
-  if (queryParams === PopularQueryParams) {
-    return popularXml
+  if (config?.params === PopularQueryParams) {
+    return popularXml as T
   }
   // TODO: support search
-  return (
+  const emptySearch =
     '<?xml version="1.0" encoding="iso-8859-1" ?>' +
     '<tags available="5180" count="0" stamp="2022-12-31 19:20:54"></tags>'
-  )
+  return emptySearch as T
 }

--- a/src/modules/getUrl.ts
+++ b/src/modules/getUrl.ts
@@ -1,21 +1,19 @@
-import axios from "axios"
-import {QueryParams} from "../constants/Search"
+import axios, {AxiosRequestConfig} from "axios"
 
-export default async function getUrl(
+export default async function getUrl<T = string>(
   baseUrl: string,
-  queryParams: QueryParams,
-): Promise<string> {
-  console.debug(
-    `getUrl: baseUrl=${baseUrl}, queryParams = ${JSON.stringify(queryParams)}`,
-  )
-  const response = await axios.get(baseUrl, {params: queryParams})
+  config: AxiosRequestConfig<any> = {},
+): Promise<T> {
+  const configDebugString = JSON.stringify(config)
+  console.debug(`getUrl: baseUrl=${baseUrl}, config = ${configDebugString}`)
+  const response = await axios.get(baseUrl, config)
   if (response.status !== 200) {
     // TODO: store debugging log
     const msg =
       response.statusText ||
       `${response.status}` ||
       `got undefined status from ${response.request.url} ` +
-        `with params ${JSON.stringify(queryParams)}`
+        `with config ${configDebugString}`
     throw Error(msg)
   }
   return response.data

--- a/src/modules/searchutil.ts
+++ b/src/modules/searchutil.ts
@@ -61,6 +61,6 @@ export async function fetchAndConvertTags(
   queryParams: QueryParams,
   baseUrl: string = Search.API_BASE,
 ): Promise<ConvertedTags> {
-  const responseText = await getUrl(baseUrl, queryParams)
+  const responseText = await getUrl(baseUrl, {params: queryParams})
   return convertTags(responseText)
 }

--- a/src/modules/sqlUtil.ts
+++ b/src/modules/sqlUtil.ts
@@ -1,0 +1,271 @@
+import getUrl from "@app/modules/getUrl"
+import {Asset} from "expo-asset"
+import * as FileSystem from "expo-file-system"
+import * as SQLite from "expo-sqlite"
+import {SQLTransactionAsyncCallback} from "expo-sqlite"
+
+// These are the parts of SQLiteDatabase we use; it's an interface so we can swap out objects in testing
+export interface InnerDb {
+  transactionAsync: (
+    asyncCallback: SQLTransactionAsyncCallback,
+    readOnly?: boolean,
+  ) => Promise<void>
+  closeAsync: () => void
+}
+type ReplaceDbCallback = () => Promise<InnerDb>
+
+/**
+ * The point of this class is to give access to the underlying database while also allowing it to be safely replaced on
+ * the fly. In particular, just writing to the file might cause corrupted reads if a query is ongoing simultaneously
+ * (which could be possible because both the queries and the writing are async and can therefore give up control),
+ * and just moving a new file atomically into place likely wouldn't get used because the underlying DB handle would be
+ * pointing at the old file descriptor.
+ *
+ * This class exposes a single entry point of `transactionAsync` and keeps track of how many active calls there are to
+ * that method. When a request comes in to replace the underlying database, it waits for all transactions to end then
+ * runs the replacement callback (which presumably changes things on disk). While the replacement callback is running,
+ * new calls to `transactionAsync` will wait until the replacement is finished, at which point pending and subsequent
+ * transactions will use the new DB.
+ *
+ * It is expected that instances of this class act a singleton points of access for a given DB path.
+ */
+export class DbWrapper {
+  private db: InnerDb
+  private txnCount: number
+  private pendingReplaceDbCallback: ReplaceDbCallback | null
+  private replaceDbInProgress: Promise<void> | null
+
+  constructor(db: InnerDb) {
+    this.db = db
+    this.txnCount = 0
+    this.pendingReplaceDbCallback = null
+    this.replaceDbInProgress = null
+  }
+
+  async transactionAsync(
+    asyncCallback: SQLTransactionAsyncCallback,
+    readOnly: boolean = false,
+  ): Promise<void> {
+    while (this.replaceDbInProgress != null) {
+      await this.replaceDbInProgress
+    }
+    this.txnCount += 1
+    await this.db.transactionAsync(asyncCallback, readOnly)
+    this.txnCount -= 1
+    this.maybeDoDbReplacement()
+  }
+
+  async queueDbReplacement(replaceDbCallback: ReplaceDbCallback) {
+    // Note: If this method is called multiple times while a replacement is in progress the first call will make
+    // progress first, which means it'll likely "win" by setting the callback, but if it's also able to immediately
+    // start the replacement the subsequent calls may remain in the while loop and effectively be "queued".
+    // Having multiple replacements simultaneously seems very unlikely to happen at all so it's not worth turning the
+    // `pendingReplaceDbCallback` into an actual queue.
+    while (this.replaceDbInProgress != null) {
+      await this.replaceDbInProgress
+    }
+    if (this.pendingReplaceDbCallback == null) {
+      this.pendingReplaceDbCallback = replaceDbCallback
+      this.maybeDoDbReplacement()
+    }
+  }
+
+  private maybeDoDbReplacement() {
+    if (
+      this.txnCount === 0 &&
+      this.pendingReplaceDbCallback != null &&
+      this.replaceDbInProgress == null
+    ) {
+      const replaceDbCallback = this.pendingReplaceDbCallback
+      // This allows others to wait until the replacement is done
+      this.replaceDbInProgress = (async () => {
+        this.db.closeAsync()
+        this.db = await replaceDbCallback()
+        this.pendingReplaceDbCallback = null
+        this.replaceDbInProgress = null
+      })()
+    }
+  }
+}
+
+/**
+ * Used to kick off the process of creating the DB and checking for updates, which can be done before we actually need
+ * access to the DB object itself.
+ */
+export function warmupDb() {
+  getDbConnection().then(/* Ignore, let run in background */)
+}
+
+// Singleton with our database. Is an array because assigning to a global wasn't updating the value on subsequent usages.
+const dbConnectionPromise: [Promise<DbWrapper> | null] = [null]
+
+/**
+ * On the first call will kick off initializing the SQL database and resolve to the DB once done. Subsequent calls
+ * will wait for that initialization (if it's in progress) or immediately resolve to the DB (if it's done).
+ */
+export async function getDbConnection(): Promise<DbWrapper> {
+  const [existing] = dbConnectionPromise
+  if (existing == null) {
+    // Initialize the database. We *must* immediately set dbConnectionPromise (before, eg, awaiting anything)
+    // to avoid race conditions.
+    console.debug("Initializing new DB wrapper")
+    const nonNullPromise = initializeDbConnection()
+    dbConnectionPromise[0] = nonNullPromise
+    return await nonNullPromise
+  } else {
+    console.debug("Using existing DB wrapper")
+    return await existing
+  }
+}
+
+const SQLITE_DIR = "SQLite"
+const TAGS_DB_NAME = "tags_db.sqlite"
+const TAGS_DB_NAME_REMOTE = "tags_db.sqlite.otf"
+const MANIFEST_NAME = "manifest.json"
+const REMOTE_ASSET_BASE_URL = "https://kamatsuoka.github.io/goodtags"
+
+const GENERATED_AT_KEY = "generated_at_epoch_seconds"
+
+/**
+ * Create the DB wrapper. Copies from the app storage if needed before creating the wrapper and kicks off a check of
+ * the remote DB after creating and returning the wrapper.
+ */
+async function initializeDbConnection(): Promise<DbWrapper> {
+  // The "SQLite" directory is required and assumed by SQLite.openDatabase
+  const sqlDir = `${FileSystem.documentDirectory}${SQLITE_DIR}/`
+  const currentSqlPath = sqlDir + TAGS_DB_NAME
+  const currentManifestPath = sqlDir + MANIFEST_NAME
+  const tmpSqlPath = `${currentSqlPath}.tmp`
+  const tmpManifestPath = `${currentManifestPath}.tmp`
+  const appSqlPath = Asset.fromModule(
+    require(`../assets/generated_db/${TAGS_DB_NAME}`),
+  ).uri
+  const appManifestObject = require(`../assets/generated_db/${MANIFEST_NAME}`)
+
+  if (!(await FileSystem.getInfoAsync(sqlDir)).exists) {
+    await FileSystem.makeDirectoryAsync(sqlDir)
+  }
+
+  // Initialize the DB from local storage if needed
+  if (
+    await shouldCopyFromApp(
+      currentSqlPath,
+      currentManifestPath,
+      appManifestObject,
+    )
+  ) {
+    console.debug("Copying DB from app storage")
+    // To avoid getting into a bad state if the app dies mid-copy, we write to temp files and then move the files into
+    // place. There's still potential for a race condition where we've moved one file but not the other, but the
+    // consequences should be much less bad (eg unlikely to brick the app).
+    await FileSystem.downloadAsync(appSqlPath, tmpSqlPath)
+    await FileSystem.writeAsStringAsync(
+      tmpManifestPath,
+      JSON.stringify(appManifestObject),
+    )
+    await FileSystem.moveAsync({from: tmpSqlPath, to: currentSqlPath})
+    await FileSystem.moveAsync({from: tmpManifestPath, to: currentManifestPath})
+  } else {
+    console.debug(
+      "Not copying DB from app storage, current DB already new enough",
+    )
+  }
+
+  // Note we intentionally are just using the basename and not the full path.
+  const dbWrapper = new DbWrapper(SQLite.openDatabase(TAGS_DB_NAME))
+
+  // We've updated based on local data, but we should also check the server for updates. Kick this off once per app
+  // open, the first time we load the DB (which should be roughly when the app is opened).
+  backgroundCheckForRemoteUpdates(
+    dbWrapper,
+    currentSqlPath,
+    currentManifestPath,
+    tmpSqlPath,
+    tmpManifestPath,
+  ).then(/* Ignore, let run in background */)
+
+  return dbWrapper
+}
+
+/** Whether we should copy the SQL and manifest from the app's built-in assets */
+async function shouldCopyFromApp(
+  currentSqlPath: string,
+  currentManifestPath: string,
+  appManifestContents: {[key: string]: any},
+): Promise<boolean> {
+  // If either are missing, we should obviously copy
+  if (
+    !(await FileSystem.getInfoAsync(currentSqlPath)).exists ||
+    !(await FileSystem.getInfoAsync(currentManifestPath)).exists
+  ) {
+    return true
+  }
+
+  // If they're present, see if the app manifest is newer
+  const currentGeneratedAt = await generatedAtFromPath(currentManifestPath)
+  const appGeneratedAt = generatedAtFromObject(appManifestContents)
+  return appGeneratedAt > currentGeneratedAt
+}
+
+async function generatedAtFromPath(manifestPath: string): Promise<number> {
+  const contents = await FileSystem.readAsStringAsync(manifestPath, {
+    encoding: "utf8",
+  })
+  return generatedAtFromObject(JSON.parse(contents))
+}
+
+function generatedAtFromObject(manifestObject: {[key: string]: any}): number {
+  return manifestObject[GENERATED_AT_KEY]
+}
+
+/**
+ * Checks for a newer DB on the server and downloads it if so, replacing the backing DB in the wrapper.
+ */
+async function backgroundCheckForRemoteUpdates(
+  dbWrapper: DbWrapper,
+  currentSqlPath: string,
+  currentManifestPath: string,
+  tmpSqlPath: string,
+  tmpManifestPath: string,
+) {
+  const remoteSqlUrl = `${REMOTE_ASSET_BASE_URL}/${TAGS_DB_NAME_REMOTE}`
+  const remoteManifestUrl = `${REMOTE_ASSET_BASE_URL}/${MANIFEST_NAME}`
+
+  // Assume we have a current manifest by this point
+  const currentGeneratedAt = await generatedAtFromPath(currentManifestPath)
+  // Get the generated at for the remote manifest
+  const remoteManifestContents = await getUrl<object>(remoteManifestUrl)
+  const remoteGeneratedAt = generatedAtFromObject(remoteManifestContents)
+
+  if (remoteGeneratedAt <= currentGeneratedAt) {
+    // It's not newer, bail
+    console.debug("Remote DB not newer, done checking for updates")
+    return
+  }
+
+  // Go ahead and download/write out both
+  // To avoid race conditions, first write out to temp files then move into place, as when copying from the app files.
+  // It's important to set the Accept-Encoding header since that should result in over-the-wire transfer sizes
+  // being reduced by ~4x
+  console.debug("Downloading remote DB")
+  await FileSystem.downloadAsync(remoteSqlUrl, tmpSqlPath, {
+    headers: {"Accept-Encoding": "gzip"},
+  })
+  await FileSystem.writeAsStringAsync(
+    tmpManifestPath,
+    JSON.stringify(remoteManifestContents),
+  )
+
+  // Actually queue up the replacement
+  dbWrapper
+    .queueDbReplacement(async () => {
+      await FileSystem.moveAsync({from: tmpSqlPath, to: currentSqlPath})
+      await FileSystem.moveAsync({
+        from: tmpManifestPath,
+        to: currentManifestPath,
+      })
+      console.debug("Done updating DB from remote")
+      return SQLite.openDatabase(TAGS_DB_NAME)
+    })
+    .then(/* ignore promise */)
+}

--- a/src/modules/sqlUtil.ts
+++ b/src/modules/sqlUtil.ts
@@ -44,7 +44,7 @@ export class DbWrapper {
     this.replaceDbInProgress = null
   }
 
-  async transactionAsync(
+  async runTransactionAsync(
     asyncCallback: SQLTransactionAsyncCallback,
     readOnly: boolean = false,
   ): Promise<void> {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,3 +2,5 @@ import "@testing-library/jest-dom"
 import "whatwg-fetch"
 
 // require("jest-fetch-mock").enableMocks()
+// Ran into this bug: https://github.com/expo/expo/issues/23591
+jest.mock("expo-font")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,10 @@
         "node_modules/react-native-paper/lib/typescript/*"
       ]
     }
+  },
+  "ts-node": {
+    "compilerOptions": {
+      "types": ["node"]
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,6 +1714,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cspotcode/source-map-support@npm:^0.8.0":
+  version: 0.8.1
+  resolution: "@cspotcode/source-map-support@npm:0.8.1"
+  dependencies:
+    "@jridgewell/trace-mapping": 0.3.9
+  checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
+  languageName: node
+  linkType: hard
+
 "@egjs/hammerjs@npm:^2.0.17":
   version: 2.0.17
   resolution: "@egjs/hammerjs@npm:2.0.17"
@@ -2133,6 +2142,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/websql@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@expo/websql@npm:1.0.1"
+  dependencies:
+    argsarray: ^0.0.1
+    immediate: ^3.2.2
+    noop-fn: ^1.0.0
+    pouchdb-collections: ^1.0.1
+    tiny-queue: ^0.2.1
+  checksum: 9458137b3c59774ca8bf18e2289ee2fd15c710a8017c84be49f78d9b988d6234b02388de2786b44ed22e906e006c3c131413e90e3b703b00886269ddea76cc5d
+  languageName: node
+  linkType: hard
+
 "@expo/xcpretty@npm:^4.2.1":
   version: 4.2.2
   resolution: "@expo/xcpretty@npm:4.2.2"
@@ -2514,6 +2536,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:^3.0.3":
+  version: 3.1.2
+  resolution: "@jridgewell/resolve-uri@npm:3.1.2"
+  checksum: 83b85f72c59d1c080b4cbec0fef84528963a1b5db34e4370fa4bd1e3ff64a0d80e0cee7369d11d73c704e0286fb2865b530acac7a871088fbe92b5edf1000870
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.1
   resolution: "@jridgewell/resolve-uri@npm:3.1.1"
@@ -2542,6 +2571,16 @@ __metadata:
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.9":
+  version: 0.3.9
+  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
   languageName: node
   linkType: hard
 
@@ -3237,6 +3276,34 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node10@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node10@npm:1.0.11"
+  checksum: 51fe47d55fe1b80ec35e6e5ed30a13665fd3a531945350aa74a14a1e82875fb60b350c2f2a5e72a64831b1b6bc02acb6760c30b3738b54954ec2dea82db7a267
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node12@npm:^1.0.7":
+  version: 1.0.11
+  resolution: "@tsconfig/node12@npm:1.0.11"
+  checksum: 5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node14@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@tsconfig/node14@npm:1.0.3"
+  checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "@tsconfig/node16@npm:1.0.4"
+  checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
   languageName: node
   linkType: hard
 
@@ -4002,12 +4069,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.1.1":
+  version: 8.3.2
+  resolution: "acorn-walk@npm:8.3.2"
+  checksum: 3626b9d26a37b1b427796feaa5261faf712307a8920392c8dce9a5739fb31077667f4ad2ec71c7ac6aaf9f61f04a9d3d67ff56f459587206fc04aa31c27ef392
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.1.0, acorn@npm:^8.8.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.10.0
   resolution: "acorn@npm:8.10.0"
   bin:
     acorn: bin/acorn
   checksum: 538ba38af0cc9e5ef983aee196c4b8b4d87c0c94532334fa7e065b2c8a1f85863467bb774231aae91613fcda5e68740c15d97b1967ae3394d20faddddd8af61d
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.4.1":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: 76d8e7d559512566b43ab4aadc374f11f563f0a9e21626dd59cb2888444e9445923ae9f3699972767f18af61df89cd89f5eaaf772d1327b055b45cb829b4a88c
   languageName: node
   linkType: hard
 
@@ -4216,6 +4299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arg@npm:^4.1.0":
+  version: 4.1.3
+  resolution: "arg@npm:4.1.3"
+  checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
@@ -4229,6 +4319,13 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"argsarray@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "argsarray@npm:0.0.1"
+  checksum: 0042accbc0a2d855ad5af56df49291e0e4cae7456f42d486f4cb05518c8e1939bf8aca7dece89d846349d615793fae2cea8ebb20a8207c0f22dafb88b1536819
   languageName: node
   linkType: hard
 
@@ -5537,6 +5634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-require@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "create-require@npm:1.1.1"
+  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
+  languageName: node
+  linkType: hard
+
 "cross-env@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-env@npm:7.0.3"
@@ -6086,6 +6190,13 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: f4914158e1f2276343d98ff5b31fc004e7304f5470bf0f1adb2ac6955d85a531a6458d33e87667f98f6ae52ebd3891bb47d420bb48a5bd8b7a27ee25b20e33aa
+  languageName: node
+  linkType: hard
+
+"diff@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "diff@npm:4.0.2"
+  checksum: f2c09b0ce4e6b301c221addd83bf3f454c0bc00caa3dd837cf6c127d6edf7223aa2bbe3b688feea110b7f262adbfc845b757c44c8a9f8c0c5b15d8fa9ce9d20d
   languageName: node
   linkType: hard
 
@@ -6972,6 +7083,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-file-system@npm:~15.4.5":
+  version: 15.4.5
+  resolution: "expo-file-system@npm:15.4.5"
+  dependencies:
+    uuid: ^3.4.0
+  peerDependencies:
+    expo: "*"
+  checksum: 3507f872a111dc2a603632d89c8c798f87927e2ab57bcd0afae34cd34423195ea8fc38a9bdceecb647f64333c6acdd9926722a43627cf5d6cdfbb204f4a0d10b
+  languageName: node
+  linkType: hard
+
 "expo-font@npm:~11.4.0":
   version: 11.4.0
   resolution: "expo-font@npm:11.4.0"
@@ -7024,6 +7146,17 @@ __metadata:
     compare-versions: ^3.4.0
     invariant: ^2.2.4
   checksum: 85a48a6d1983671458a37ddece9e151ff8179814dd368d67b39dcf34fcdc6b44419d045ac8efcdd8179848d826b67678ce706f5533314ff8ab84537befcf7915
+  languageName: node
+  linkType: hard
+
+"expo-sqlite@npm:~11.3.3":
+  version: 11.3.3
+  resolution: "expo-sqlite@npm:11.3.3"
+  dependencies:
+    "@expo/websql": ^1.0.1
+  peerDependencies:
+    expo: "*"
+  checksum: 254931f02fd39440a6898bb1cf0f95c46d14edc64d09559762043bf6a81292d19bf26d75d9f739c6a3150c4e2f976fd1ab9a2bb5fbde5754d35497fcbacc9f1e
   languageName: node
   linkType: hard
 
@@ -7813,7 +7946,10 @@ __metadata:
     eslint-plugin-jest: ^27.1.7
     eslint-plugin-prettier: ^5.0.0
     expo: ^49.0.0
+    expo-asset: ~8.10.1
+    expo-file-system: ~15.4.5
     expo-haptics: ~12.4.0
+    expo-sqlite: ~11.3.3
     fast-xml-parser: ^4.0.12
     html-entities: ^2.3.3
     husky: ">=6"
@@ -7854,6 +7990,7 @@ __metadata:
     redux-persist: ^6.0.0
     redux-thunk: ^2.4.2
     semver: ^7.5.2
+    ts-node: ^10.9.2
     typescript: ^5.1.3
   languageName: unknown
   linkType: soft
@@ -8163,6 +8300,13 @@ __metadata:
   bin:
     image-size: bin/image-size.js
   checksum: 01745fdb47f87cecf538e69c63f9adc5bfab30a345345c2de91105f3afbd1bfcfba1256af02bf3323077b33b0004469a837e077bf0cbb9c907e9c1e9e7547585
+  languageName: node
+  linkType: hard
+
+"immediate@npm:^3.2.2":
+  version: 3.3.0
+  resolution: "immediate@npm:3.3.0"
+  checksum: 634b4305101e2452eba6c07d485bf3e415995e533c94b9c3ffbc37026fa1be34def6e4f2276b0dc2162a3f91628564a4bfb26280278b89d3ee54624e854d2f5f
   languageName: node
   linkType: hard
 
@@ -10096,6 +10240,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-error@npm:^1.1.1":
+  version: 1.3.6
+  resolution: "make-error@npm:1.3.6"
+  checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^11.0.3":
   version: 11.1.1
   resolution: "make-fetch-happen@npm:11.1.1"
@@ -11007,6 +11158,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"noop-fn@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "noop-fn@npm:1.0.0"
+  checksum: e271f0590c06283d6216e268507fdab066d52164d7281cef1b99a2f40442c85297341c0e37a8fcbc9da95ea6cead7a87a69937c71a80fb3630b909d08b4e8c19
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^6.0.0":
   version: 6.0.0
   resolution: "nopt@npm:6.0.0"
@@ -11658,6 +11816,13 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 1d8611341b073143ad90486fcdfeab49edd243377b1f51834dc4f6d028e82ce5190e4f11bb2633276864503654fb7cab28e67abdc0fbf9d1f88cad4a0ff0beea
+  languageName: node
+  linkType: hard
+
+"pouchdb-collections@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "pouchdb-collections@npm:1.0.1"
+  checksum: 5ac0c3f678406c143d99f5706123ab7d65bfd60a481a7eae2487ad355f5d3c926af0f0acfa9e47ff3e9d2aa0a782cca4431a37ba77d1a02cfd380c5cf5d6aef8
   languageName: node
   linkType: hard
 
@@ -13943,6 +14108,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-queue@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "tiny-queue@npm:0.2.1"
+  checksum: 9fb00beb47da966cc9296af5049077a656f6111ffb5a20b38a068659b30d8459f8f80b7bcf938e15547c321ecb7da8d001f38c2c847c0492633ae3b69550a4df
+  languageName: node
+  linkType: hard
+
 "titleize@npm:^3.0.0":
   version: 3.0.0
   resolution: "titleize@npm:3.0.0"
@@ -14055,6 +14227,44 @@ __metadata:
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 20c29189c2dd6067a8775e07823ddf8d59a33e2ffc47a1bd59a5cb28bb0121a2969a816d5e77eda2ed85b18171aa5d1c4005a6b88ae8499ec7cc49f78571cb5e
+  languageName: node
+  linkType: hard
+
+"ts-node@npm:^10.9.2":
+  version: 10.9.2
+  resolution: "ts-node@npm:10.9.2"
+  dependencies:
+    "@cspotcode/source-map-support": ^0.8.0
+    "@tsconfig/node10": ^1.0.7
+    "@tsconfig/node12": ^1.0.7
+    "@tsconfig/node14": ^1.0.0
+    "@tsconfig/node16": ^1.0.2
+    acorn: ^8.4.1
+    acorn-walk: ^8.1.1
+    arg: ^4.1.0
+    create-require: ^1.1.0
+    diff: ^4.0.1
+    make-error: ^1.1.1
+    v8-compile-cache-lib: ^3.0.1
+    yn: 3.1.1
+  peerDependencies:
+    "@swc/core": ">=1.2.50"
+    "@swc/wasm": ">=1.2.50"
+    "@types/node": "*"
+    typescript: ">=2.7"
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+    "@swc/wasm":
+      optional: true
+  bin:
+    ts-node: dist/bin.js
+    ts-node-cwd: dist/bin-cwd.js
+    ts-node-esm: dist/bin-esm.js
+    ts-node-script: dist/bin-script.js
+    ts-node-transpile-only: dist/bin-transpile.js
+    ts-script: dist/bin-script-deprecated.js
+  checksum: fde256c9073969e234526e2cfead42591b9a2aec5222bac154b0de2fa9e4ceb30efcd717ee8bc785a56f3a119bdd5aa27b333d9dbec94ed254bd26f8944c67ac
   languageName: node
   linkType: hard
 
@@ -14514,6 +14724,13 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"v8-compile-cache-lib@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "v8-compile-cache-lib@npm:3.0.1"
+  checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
   languageName: node
   linkType: hard
 
@@ -15052,6 +15269,13 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
+  languageName: node
+  linkType: hard
+
+"yn@npm:3.1.1":
+  version: 3.1.1
+  resolution: "yn@npm:3.1.1"
+  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,10 +3496,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.11.9":
-  version: 18.18.6
-  resolution: "@types/node@npm:18.18.6"
-  checksum: a847639b8455fd3dfa6dbc2917274c82c9db789f1d41aaf69f94ac6c9e54c3c1dd29be6e1e1ccd7c17e54db3d78d7011bc4e70544c6447ceca253dccc0a187e1
+"@types/node@npm:^20.12.7":
+  version: 20.12.7
+  resolution: "@types/node@npm:20.12.7"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: 7cc979f7e2ca9a339ec71318c3901b9978555257929ef3666987f3e447123bc6dc92afcc89f6347e09e07d602fde7d51bcddea626c23aa2bb74aeaacfd1e1686
   languageName: node
   linkType: hard
 
@@ -7930,7 +7932,7 @@ __metadata:
     "@types/color": ^3.0.3
     "@types/jest": ^26.0.23
     "@types/lodash": ^4.14.189
-    "@types/node": ^18.11.9
+    "@types/node": ^20.12.7
     "@types/react": ^18.0.24
     "@types/react-native-vector-icons": ^6.4.12
     "@types/react-test-renderer": ^18.0.0
@@ -14491,6 +14493,13 @@ __metadata:
   version: 5.25.3
   resolution: "undici-types@npm:5.25.3"
   checksum: ec9d2cc36520cbd9fbe3b3b6c682a87fe5be214699e1f57d1e3d9a2cb5be422e62735f06e0067dc325fd3dd7404c697e4d479f9147dc8a804e049e29f357f2ff
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is the second phase in modifying goodtags for ~instant offline search. To recap, at a high level, the cumulative set of changes will look like:
1. Have something that periodically snapshots the canonical barbershoptags.com database into a SQL database suitable for use by the app and host that where the app can download it (https://github.com/kamatsuoka/goodtags/pull/7).
2. Update the app to include the latest (at the time) database when compiling it and fetch the latest database on startup, only downloading it if it's actually newer than what the app already has (**this PR**).
3. Update the app to add a parallel code path to direct searches to the database rather than the API.
4. Once this has been validated, rip out the old code path and solely rely on the local database for searches.

There are two main changes in the PR: ensuring the latest database is downloaded at build time, and downloading the latest database at app startup time.

At build time there's a new `yarn download-search-db` task which pulls the latest DB into the `src/assets/generated_db/` folder. This task is then invoked as a prerequisite for a number of the other `yarn` tasks as well as in the gradle and xcode build configs. This also modifies the Metro config to include the `.sqlite` file as an asset in the bundle.

At app startup time, there's a new utility for transparently ensuring the database is available and kicking off a background update. This code path will copy the database from the app bundle produced by Metro into the app's local storage if there isn't already a database or the one that's already there is older (as determined by the accompanying manifest). It'll then read the remote manifest and, if that's newer, download that database and seamlessly switch out the backing database instance with the new file. That switching out of the existing database is facilitated by the new `DbWrapper` class which tracks live transactions and replaces the underlying database once there are no more transactions; it's effectively a RW lock on the database. All this code relies on promises (which return ~instantly once they're resolved) so the calling code doesn't need to know about any of those details, it just says "give me a database and run this transaction on it".

To test this, I've written some Jest tests for the `DbWrapper` class and have manually tested the in-app update flows:
- No existing local DB -> copy from bundle
- Bundle/app DB newer than local DB -> copy from bundle
- Bundle/app DB older than/same as local DB -> no copy
- Remote DB newer than local DB -> copy from remote
- Remote DB older than/same as local DB -> no copy

Ideally I'd automate these tests with detox but that setup seems to have atrophied and I wasn't able to get it working in a somewhat short amount of time. I may still look into fixing that up (and getting it running in CI) and then automating these tests, but that would be in a subsequent PR.