### PR TITLE
Fix TypeScript errors and check types in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,8 @@ jobs:
         uses: borales/actions-yarn@v4.2.0
         with:
           cmd: test
+      - name: typecheck the app
+        uses: borales/actions-yarn@v4.2.0
+        with:
+          # Using --noEmit because we only care about typechecking, not compiling
+          cmd: run tsc --noEmit

--- a/__mocks__/@react-native-async-storage/async-storage.js
+++ b/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,2 +1,1 @@
-// @ts-ignore
-export default from "@react-native-async-storage/async-storage/jest/async-storage-mock"
+export * from "@react-native-async-storage/async-storage/jest/async-storage-mock"

--- a/src/components/CreateLabel.tsx
+++ b/src/components/CreateLabel.tsx
@@ -5,8 +5,7 @@ import {useNavigation} from "@react-navigation/native"
 import {NativeStackScreenProps} from "@react-navigation/native-stack"
 import {useState} from "react"
 import {StyleSheet, View} from "react-native"
-import {Text, TextInput} from "react-native-paper"
-import {useTheme} from "react-native-paper/src/core/theming"
+import {Text, TextInput, useTheme} from "react-native-paper"
 
 type Props = NativeStackScreenProps<StackParamList, "CreateLabel">
 

--- a/src/components/FABDown.tsx
+++ b/src/components/FABDown.tsx
@@ -10,15 +10,12 @@ import {
   ViewStyle,
 } from "react-native"
 
+import {Card, FAB, Text} from "react-native-paper"
+import {getFABGroupColors} from "react-native-paper/lib/typescript/components/FAB/utils"
+import {IconSource} from "react-native-paper/lib/typescript/components/Icon"
+import {withInternalTheme} from "react-native-paper/lib/typescript/core/theming"
+import {InternalTheme} from "react-native-paper/lib/typescript/types"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
-
-import {withInternalTheme} from "react-native-paper/src/core/theming"
-import type {InternalTheme} from "react-native-paper/src/types"
-import Card from "react-native-paper/src/components/Card/Card"
-import type {IconSource} from "react-native-paper/src/components/Icon"
-import Text from "react-native-paper/src/components/Typography/Text"
-import FAB from "react-native-paper/src/components/FAB/FAB"
-import {getFABGroupColors} from "react-native-paper/src/components/FAB/utils"
 
 export type Props = {
   /**

--- a/src/components/LabelEditor.tsx
+++ b/src/components/LabelEditor.tsx
@@ -11,8 +11,14 @@ import {
   NestableScrollContainer,
   RenderItemParams,
 } from "react-native-draggable-flatlist"
-import {Button, Dialog, IconButton, Text, TextInput} from "react-native-paper"
-import {useTheme} from "react-native-paper/src/core/theming"
+import {
+  Button,
+  Dialog,
+  IconButton,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper"
 import Animated, {FadeIn, FadeOut} from "react-native-reanimated"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
 

--- a/src/components/NoteButton.tsx
+++ b/src/components/NoteButton.tsx
@@ -1,6 +1,5 @@
-import React from "react"
+import {ColorValue, Platform, StyleSheet, View} from "react-native"
 import {Text, useTheme} from "react-native-paper"
-import {ColorValue, Platform, StyleSheet, View, ViewStyle} from "react-native"
 
 type ComponentProps = {
   note: string
@@ -59,7 +58,7 @@ const NoteButton = (props: Props) => {
     const label = noteLabel(props.note)
     const labelHolderStyle =
       Platform.OS === "ios" && label.length > 1
-        ? StyleSheet.compose<ViewStyle>(styles.labelHolder, {left: 3})
+        ? StyleSheet.compose(styles.labelHolder, {left: 3})
         : styles.labelHolder
     return Platform.OS === "ios" ? (
       <View style={labelHolderStyle}>

--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -1,6 +1,11 @@
 import {StyleProp, StyleSheet, View, ViewStyle} from "react-native"
-import {Divider, Surface, Text, useTheme} from "react-native-paper"
-import {MD3TypescaleKey} from "react-native-paper/src/types"
+import {
+  Divider,
+  MD3TypescaleKey,
+  Surface,
+  Text,
+  useTheme,
+} from "react-native-paper"
 import Icon from "react-native-vector-icons/MaterialCommunityIcons"
 
 type Props = {

--- a/src/components/VideoView.tsx
+++ b/src/components/VideoView.tsx
@@ -1,8 +1,8 @@
-import {Dimensions, StyleSheet, View, ViewStyle} from "react-native"
+import {useState} from "react"
+import {Dimensions, StyleSheet, View} from "react-native"
 import {IconButton, useTheme} from "react-native-paper"
-import React, {useState} from "react"
-import Tag, {Video} from "../lib/models/Tag"
 import YoutubePlayer from "react-native-youtube-iframe"
+import Tag, {Video} from "../lib/models/Tag"
 
 /**
  * View youtube videos for a tag
@@ -71,7 +71,7 @@ const VideoView = (props: {tag: Tag}) => {
 
   const videoSize = getVideoSize()
   const buttonMode = "contained"
-  const bodyStyle = StyleSheet.compose<ViewStyle>(styles.body, videoSize)
+  const bodyStyle = StyleSheet.compose(styles.body, videoSize)
 
   return (
     <View style={bodyStyle}>

--- a/src/lib/NotePlayer.ts
+++ b/src/lib/NotePlayer.ts
@@ -7,7 +7,10 @@ class RampDownParams {
   delay: number
   increment: number
 
-  constructor(readonly totalTime: number, readonly divs: number) {
+  constructor(
+    readonly totalTime: number,
+    readonly divs: number,
+  ) {
     this.delay = totalTime / divs
     this.increment = 1.0 / divs
   }
@@ -22,7 +25,7 @@ export class NotePlayer {
   note: string
   sound: Sound
   playing: boolean = false
-  timeoutId: number | undefined = undefined
+  timeoutId: ReturnType<typeof setTimeout> | undefined = undefined
 
   constructor(note: string, sound: Sound) {
     this.note = note

--- a/src/screens/TagScreen.tsx
+++ b/src/screens/TagScreen.tsx
@@ -8,7 +8,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   View,
-  ViewStyle,
 } from "react-native"
 import CommonStyles from "../constants/CommonStyles"
 // @ts-ignore
@@ -154,7 +153,7 @@ const TagScreen = ({navigation}: Props) => {
     modalCloseButtonStyle.left += insets.left
   }
 
-  const videoModalStyle = StyleSheet.compose<ViewStyle>(
+  const videoModalStyle = StyleSheet.compose(
     themedStyles.modal,
     themedStyles.videoModal,
   )


### PR DESCRIPTION
This fixes errors discovered by `yarn run tsc -- --noEmit` (the last arg to skip outputting compiled files we don't care about) and adds that check to CI to keep the project clean. I was wondering why a type error in another change of mine wasn't caught, and this was the reason. In particular the `export default from` error in the `async-storage.js` mock seemed like a parse error that stopped it from discovering any other issues.

The fixes fall into a few categories:
- Fix the async-storage mock in line with the docs at https://react-native-async-storage.github.io/async-storage/docs/advanced/jest/.
- Use the official/compiled import entrypoints for `react-native-paper` and not their raw source code (eg avoid everything in the `src/` directory) which in turn means we're no longer incorrectly type checking their code.
- Remove the `<ViewStyle>` explicit types from `StyleSheet.compose` since it was complaining about not enough type arguments, but can infer the types just fine and matches the examples at https://reactnative.dev/docs/stylesheet#compose.
- Use a more generic return type for `setTimeout` (it maybe seems to think it's using Node types there? I dunno this fix was recommended by https://stackoverflow.com/questions/45802988/typescript-use-correct-version-of-settimeout-node-vs-window).