### PR TITLE
Fix build after TypeScript fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /.yarn/releases/** binary
 /.yarn/plugins/** binary
+yarn.lock linguist-generated

--- a/src/components/FABDown.tsx
+++ b/src/components/FABDown.tsx
@@ -11,9 +11,9 @@ import {
 } from "react-native"
 
 import {Card, FAB, Text} from "react-native-paper"
-import {getFABGroupColors} from "react-native-paper/lib/typescript/components/FAB/utils"
-import {IconSource} from "react-native-paper/lib/typescript/components/Icon"
-import {withInternalTheme} from "react-native-paper/lib/typescript/core/theming"
+import {getFABGroupColors} from "react-native-paper/lib/module/components/FAB/utils"
+import {IconSource} from "react-native-paper/lib/module/components/Icon"
+import {withInternalTheme} from "react-native-paper/lib/module/core/theming"
 import {InternalTheme} from "react-native-paper/lib/typescript/types"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
     "paths": {
       "@app/*": [
         "src/*"
+      ],
+      "react-native-paper/lib/module/*": [
+        "node_modules/react-native-paper/lib/typescript/*"
       ]
     }
   }


### PR DESCRIPTION
So it turns out there was a good reason to not use the `lib/typescript` parts of `react-native-paper` in that those look to be *only* the type definitions and not the implementation, which meant that at build/run time it failed to import correctly. This changes some of them to `lib/module` (which is the actual compiled code) and then tells TypeScript where to look for the type definitions for those files by modifying the `paths` in `tsconfig.json`. Note that in the docs they recommend against using `paths` to point into `node_modules`, but that seems to be when referring to an entire package and some of the issues they're warning about there don't seem to be coming up here (eg other aspects of the `package.json` being ignored).

Also mark yarn.lock as generated, since I've been wanting that for a bit and it's a small change