### PR TITLE
[Offline search] Hook up database for full offline search

### DIFF
--- a/src/components/SearchDialog.tsx
+++ b/src/components/SearchDialog.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
 } from "react-native-paper"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
-import {Collection, Mode, Parts} from "../constants/Search"
+import {Collection, Parts} from "../constants/Search"
 import {useAppDispatch, useAppSelector} from "../hooks"
 import {
   SearchFilters,
@@ -75,8 +75,12 @@ export default function SearchDialog(props: Props) {
       paddingVertical: 3,
     },
     infoButton: {
-      paddingLeft: 0,
-      marginHorizontal: 3,
+      paddingLeft: 10,
+      marginHorizontal: 5,
+    },
+    offlineTitle: {
+      padding: 0,
+      paddingLeft: 10,
     },
   })
 
@@ -195,30 +199,10 @@ export default function SearchDialog(props: Props) {
               })}
             </RadioButton.Group>
           </SearchOptions>
-          <SearchOptions title="mode" icon="cog-outline">
-            <RadioButton.Group
-              onValueChange={value =>
-                setDraftFilters({
-                  ...draftFilters,
-                  mode: value as Mode,
-                })
-              }
-              value={draftFilters.mode}>
-              {Object.values(Mode).map(value => {
-                return (
-                  <View key={`mode_${value}`} style={styles.optionsContainer}>
-                    <RadioButton.Item
-                      label={value.toLowerCase()}
-                      labelStyle={styles.optionText}
-                      position="leading"
-                      style={styles.checkboxItem}
-                      value={value}
-                    />
-                  </View>
-                )
-              })}
-            </RadioButton.Group>
-            <IconButton
+          <SearchOptions
+            title="offline"
+            icon="cog-outline"
+            infoButton=<IconButton
               style={styles.infoButton}
               icon="information-outline"
               onPress={() => {
@@ -226,6 +210,22 @@ export default function SearchDialog(props: Props) {
                 Keyboard.dismiss()
               }}
             />
+            titleStyle={styles.offlineTitle}>
+            <View style={styles.optionsContainer}>
+              <Checkbox.Item
+                label="enabled"
+                labelStyle={styles.optionText}
+                style={styles.checkboxItem}
+                position="leading"
+                status={draftFilters.offline ? "checked" : "unchecked"}
+                onPress={() =>
+                  setDraftFilters({
+                    ...draftFilters,
+                    offline: !draftFilters.offline,
+                  })
+                }
+              />
+            </View>
           </SearchOptions>
         </View>
       </Pressable>

--- a/src/components/SearchDialog.tsx
+++ b/src/components/SearchDialog.tsx
@@ -243,11 +243,6 @@ export default function SearchDialog(props: Props) {
               just for searching; viewing a non-favorited individual tag still
               requires internet.
             </Text>
-            <Text>{/* blank line */}</Text>
-            <Text variant="bodyMedium">
-              The offline search will be default soon, if you run into any
-              problems with it, please reach out to ???.
-            </Text>
             <Dialog.Actions>
               <Button onPress={() => setModeExplanationDialogVisible(false)}>
                 Ok

--- a/src/components/SearchDialog.tsx
+++ b/src/components/SearchDialog.tsx
@@ -1,9 +1,19 @@
 import useHaptics from "@app/hooks/useHaptics"
 import {useState} from "react"
 import {Keyboard, Pressable, StyleSheet, View} from "react-native"
-import {Checkbox, RadioButton, Searchbar, useTheme} from "react-native-paper"
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  IconButton,
+  Portal,
+  RadioButton,
+  Searchbar,
+  Text,
+  useTheme,
+} from "react-native-paper"
 import {useSafeAreaInsets} from "react-native-safe-area-context"
-import {Collection, Parts} from "../constants/Search"
+import {Collection, Mode, Parts} from "../constants/Search"
 import {useAppDispatch, useAppSelector} from "../hooks"
 import {
   SearchFilters,
@@ -28,6 +38,8 @@ export default function SearchDialog(props: Props) {
   const allTagIds = useAppSelector(
     state => selectSearchResults(state).allTagIds,
   )
+  const [modeExplanationDialogVisible, setModeExplanationDialogVisible] =
+    useState(false)
 
   const styles = StyleSheet.create({
     container: {
@@ -61,6 +73,10 @@ export default function SearchDialog(props: Props) {
       paddingLeft: 0,
       paddingRight: 5,
       paddingVertical: 3,
+    },
+    infoButton: {
+      paddingLeft: 0,
+      marginHorizontal: 3,
     },
   })
 
@@ -179,8 +195,67 @@ export default function SearchDialog(props: Props) {
               })}
             </RadioButton.Group>
           </SearchOptions>
+          <SearchOptions title="mode" icon="cog-outline">
+            <RadioButton.Group
+              onValueChange={value =>
+                setDraftFilters({
+                  ...draftFilters,
+                  mode: value as Mode,
+                })
+              }
+              value={draftFilters.mode}>
+              {Object.values(Mode).map(value => {
+                return (
+                  <View key={`mode_${value}`} style={styles.optionsContainer}>
+                    <RadioButton.Item
+                      label={value.toLowerCase()}
+                      labelStyle={styles.optionText}
+                      position="leading"
+                      style={styles.checkboxItem}
+                      value={value}
+                    />
+                  </View>
+                )
+              })}
+            </RadioButton.Group>
+            <IconButton
+              style={styles.infoButton}
+              icon="information-outline"
+              onPress={() => {
+                setModeExplanationDialogVisible(true)
+                Keyboard.dismiss()
+              }}
+            />
+          </SearchOptions>
         </View>
       </Pressable>
+      <Portal>
+        <Dialog
+          visible={modeExplanationDialogVisible}
+          onDismiss={() => setModeExplanationDialogVisible(false)}
+          // It's otherwise a *very* round dialog
+          theme={{...theme, roundness: 3}}>
+          <Dialog.Title>Search mode</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">
+              The newer offline search is faster but may not show the same
+              results, and results may be slightly less up-to-date. Note this is
+              just for searching; viewing a non-favorited individual tag still
+              requires internet.
+            </Text>
+            <Text>{/* blank line */}</Text>
+            <Text variant="bodyMedium">
+              The offline search will be default soon, if you run into any
+              problems with it, please reach out to ???.
+            </Text>
+            <Dialog.Actions>
+              <Button onPress={() => setModeExplanationDialogVisible(false)}>
+                Ok
+              </Button>
+            </Dialog.Actions>
+          </Dialog.Content>
+        </Dialog>
+      </Portal>
     </View>
   )
 }

--- a/src/components/SearchOptions.tsx
+++ b/src/components/SearchOptions.tsx
@@ -16,6 +16,8 @@ type Props = {
   titleVariant?: keyof typeof MD3TypescaleKey
   rightStyle?: StyleProp<ViewStyle>
   children: React.ReactNode
+  infoButton?: React.ReactNode
+  titleStyle?: StyleProp<ViewStyle>
 }
 
 /**
@@ -29,6 +31,8 @@ const SearchOptions = ({
   titleVariant = "bodyLarge",
   rightStyle,
   children,
+  infoButton,
+  titleStyle,
 }: Props) => {
   const theme = useTheme()
 
@@ -42,7 +46,7 @@ const SearchOptions = ({
 
   return (
     <Surface style={styles.container}>
-      <View style={styles.titleContainer}>
+      <View style={[styles.titleContainer, titleStyle]}>
         <View style={rightStyle}>
           <Icon
             name={icon}
@@ -53,6 +57,7 @@ const SearchOptions = ({
         <Text style={styles.title} numberOfLines={1} variant={titleVariant}>
           {title}
         </Text>
+        {infoButton}
       </View>
       <Divider bold />
       <View style={themedStyles.optionsContainer}>{children}</View>

--- a/src/constants/Search.ts
+++ b/src/constants/Search.ts
@@ -6,11 +6,6 @@ export enum Collection {
   EASY = "Easy",
 }
 
-export enum Mode {
-  OFFLINE = "offline",
-  ONLINE = "online",
-}
-
 export const Search = {
   TITLE: "Title",
   DOWNLOADS: "Downloads",

--- a/src/constants/Search.ts
+++ b/src/constants/Search.ts
@@ -6,6 +6,11 @@ export enum Collection {
   EASY = "Easy",
 }
 
+export enum Mode {
+  OFFLINE = "offline",
+  ONLINE = "online",
+}
+
 export const Search = {
   TITLE: "Title",
   DOWNLOADS: "Downloads",
@@ -13,16 +18,18 @@ export const Search = {
   TAGS_PER_QUERY: 33,
   API_BASE: "https://www.barbershoptags.com/api.php?client=goodtags",
 }
-export type QueryParams = {
-  q?: string
-  start?: number
+export type SearchParams = {
+  // Filter what we're looking for
   id?: number
-  n?: number
-  Collection?: string
-  Sortby?: string
-  SheetMusic?: string
-  Learning?: string
-  Parts?: number
+  query?: string
+  collection?: Collection
+  parts?: number
+  requireSheetMusic?: boolean
+  requireLearningTracks?: boolean
+  // Control how we render the results we've filtered to
+  sortBy?: SortOrder
+  offset?: number
+  limit?: number
 }
 
 export enum SortOrder {

--- a/src/lib/models/__tests__/tag.test.ts
+++ b/src/lib/models/__tests__/tag.test.ts
@@ -1,5 +1,5 @@
 import {findNonSerializableValue} from "@reduxjs/toolkit"
-import {buildSearchResult, buildTagIds, XmlTag} from "../Tag"
+import {XmlTag, buildTagIds, tagFromApiXml} from "../Tag"
 
 // result of calling parseXml on api response text
 // and gettine one of xml.tags.tag[]
@@ -62,9 +62,9 @@ const xmlTag: XmlTag = {
   },
 }
 
-describe("buildSearchResult", () => {
+describe("tagFromApiXml", () => {
   it("should extract values", () => {
-    const r = buildSearchResult(xmlTag)
+    const r = tagFromApiXml(xmlTag)
     expect(r).toEqual({
       id: 1809,
       title: "Lost",
@@ -114,7 +114,7 @@ describe("buildSearchResult", () => {
         },
       ],
       version: 5,
-      searchResultIndex: 1,
+      searchResultIndex: 0,
       downloaded: 134646,
     })
   })
@@ -122,7 +122,7 @@ describe("buildSearchResult", () => {
 
 describe("buildTagIds", () => {
   it("should produce serializable results", () => {
-    const searchResult = buildSearchResult(xmlTag)
+    const searchResult = tagFromApiXml(xmlTag)
     const {tagsById} = buildTagIds([searchResult])
     const nonser = findNonSerializableValue(tagsById, "test ser")
     expect(nonser).toBe(false)

--- a/src/modules/favoritesSlice.ts
+++ b/src/modules/favoritesSlice.ts
@@ -277,11 +277,11 @@ export const refreshFavorite = createAsyncThunk<
   try {
     let convertedTags: ConvertedTags
     try {
-      convertedTags = await fetchAndConvertTags({id})
+      convertedTags = await fetchAndConvertTags({id}, false /* useApi */)
     } catch (e) {
       console.log(e)
       const baseUrl = `https://kenjimatsuoka.net/goodtags/xml/${id}.xml` // TODO
-      convertedTags = await fetchAndConvertTags({}, baseUrl)
+      convertedTags = await fetchAndConvertTags({}, false /* useApi */, baseUrl)
     }
     const {tags} = convertedTags
     return tags?.[0] || thunkAPI.rejectWithValue(`Tag ${id} not found`)

--- a/src/modules/getUrl.e2e.ts
+++ b/src/modules/getUrl.e2e.ts
@@ -1,4 +1,4 @@
-import {PopularQueryParams} from "@app/modules/popularSlice"
+import {PopularSearchParams} from "@app/modules/popularSlice"
 import {AxiosRequestConfig} from "axios"
 import {popularXml} from "./__mocks__/popular.xml"
 
@@ -12,7 +12,7 @@ export default async function getUrl<T = string>(
   console.debug(
     `getUrl.e2e: baseUrl=${baseUrl}, config = ${JSON.stringify(config)}`,
   )
-  if (config?.params === PopularQueryParams) {
+  if (config?.params === PopularSearchParams) {
     return popularXml as T
   }
   // TODO: support search

--- a/src/modules/popularSlice.ts
+++ b/src/modules/popularSlice.ts
@@ -1,5 +1,5 @@
 import {createAsyncThunk, createSlice, PayloadAction} from "@reduxjs/toolkit"
-import {QueryParams, SortOrder} from "../constants/Search"
+import {SearchParams, SortOrder} from "../constants/Search"
 import {
   buildTagIds,
   CurrentTagVersion,
@@ -8,7 +8,7 @@ import {
 } from "../lib/models/Tag"
 import {RootState} from "../store"
 import {handleError} from "./handleError"
-import {fetchAndConvertTags, SORTBY_PARAMS} from "./searchutil"
+import {fetchAndConvertTags} from "./searchutil"
 import {LoadingState, sortAlpha, TagListState} from "./tagLists"
 import {SelectedTag} from "./tagListUtil"
 import {ThunkApiConfig} from "./thunkApiConfig"
@@ -114,10 +114,10 @@ function outdatedSearchResults(
 }
 
 // always sort by downloads when fetching from server
-export const PopularQueryParams: QueryParams = {
-  Sortby: SORTBY_PARAMS[SortOrder.downloads],
-  n: MaxPopular,
-  SheetMusic: "Yes",
+export const PopularSearchParams: SearchParams = {
+  sortBy: SortOrder.downloads,
+  limit: MaxPopular,
+  requireSheetMusic: true,
 }
 
 /**
@@ -137,7 +137,10 @@ export const getPopularTags = createAsyncThunk<
     outdatedSearchResults(state.tagsById, state.allTagIds)
   ) {
     try {
-      const fetchResult = await fetchAndConvertTags(PopularQueryParams)
+      const fetchResult = await fetchAndConvertTags(
+        PopularSearchParams,
+        false /* useApi */,
+      )
       return fetchResult.tags
     } catch (error) {
       const payload = await handleError(error, `getPopularTags`)

--- a/src/modules/searchSlice.ts
+++ b/src/modules/searchSlice.ts
@@ -4,7 +4,7 @@ import {
   createSlice,
   PayloadAction,
 } from "@reduxjs/toolkit"
-import {Collection, Mode, Parts, SortOrder} from "../constants/Search"
+import {Collection, Parts, SortOrder} from "../constants/Search"
 import {
   buildTagIds,
   ConvertedTags,
@@ -31,7 +31,8 @@ export interface SearchFilters {
   sheetMusic: boolean
   collection: Collection
   parts: Parts
-  mode: Mode
+  mode: string // deprecated
+  offline: boolean
 }
 
 interface Results {
@@ -69,7 +70,8 @@ export const InitialFilters: SearchFilters = {
   sheetMusic: true,
   collection: Collection.ALL,
   parts: Parts.any,
-  mode: Mode.OFFLINE,
+  mode: "OFFLINE",
+  offline: true,
 }
 
 const initialResults: Results = {
@@ -162,7 +164,7 @@ async function fetchTags(
   state: SearchState,
   start: number,
 ): Promise<SearchPayload> {
-  const useApi = state.filters.mode === Mode.ONLINE
+  const useApi = !state.filters.offline
   const searchParams = getSearchParams(state, start, useApi)
   const fetchResult: ConvertedTags = await fetchAndConvertTags(
     searchParams,

--- a/src/modules/searchSlice.ts
+++ b/src/modules/searchSlice.ts
@@ -165,7 +165,7 @@ async function fetchTags(
   start: number,
 ): Promise<SearchPayload> {
   const useApi = !state.filters.offline
-  const searchParams = getSearchParams(state, start, useApi)
+  const searchParams = getSearchParams(state, start)
   const fetchResult: ConvertedTags = await fetchAndConvertTags(
     searchParams,
     useApi,

--- a/src/modules/searchutil.ts
+++ b/src/modules/searchutil.ts
@@ -40,11 +40,10 @@ export const PARTS_PARAMS = {
 export function getSearchParams(
   state: SearchState,
   start: number,
-  useApi: boolean,
 ): SearchParams {
   const trimQuery = state.query.trim()
   const cleanQuery = trimQuery.replace(/[^a-zA-Z0-9]/g, " ").trim()
-  if (useApi && isId(cleanQuery)) {
+  if (isId(cleanQuery)) {
     // treat numeric query as request for tag by id (rip 1776 tag)
     return {id: toInteger(cleanQuery)}
   }

--- a/src/modules/searchutil.ts
+++ b/src/modules/searchutil.ts
@@ -1,12 +1,17 @@
+import {getDbConnection} from "@app/modules/sqlUtil"
 import {toInteger} from "lodash"
 import {
   Collection,
   Parts,
-  QueryParams,
   Search,
+  SearchParams,
   SortOrder,
 } from "../constants/Search"
-import {ConvertedTags, convertTags} from "../lib/models/Tag"
+import {
+  ConvertedTags,
+  tagsFromApiResponse,
+  tagsFromDbRows,
+} from "../lib/models/Tag"
 import getUrl from "./getUrl"
 import {SearchState} from "./searchSlice"
 
@@ -26,41 +31,236 @@ export const SORTBY_PARAMS = {
 }
 
 export const PARTS_PARAMS = {
+  [Parts.any]: undefined,
   [Parts.four]: 4,
   [Parts.five]: 5,
   [Parts.six]: 6,
 }
 
-export function getQueryParams(state: SearchState, start: number): QueryParams {
+export function getSearchParams(
+  state: SearchState,
+  start: number,
+  useApi: boolean,
+): SearchParams {
   const trimQuery = state.query.trim()
   const cleanQuery = trimQuery.replace(/[^a-zA-Z0-9]/g, " ").trim()
-  if (isId(cleanQuery)) {
+  if (useApi && isId(cleanQuery)) {
     // treat numeric query as request for tag by id (rip 1776 tag)
     return {id: toInteger(cleanQuery)}
   }
-  const params: QueryParams = {
-    Collection: COLLECTION_PARAMS[state.filters.collection],
-    Sortby: SORTBY_PARAMS[state.sortOrder],
-    n: Search.TAGS_PER_QUERY,
-    start: start,
-    q: cleanQuery,
+
+  return {
+    collection: state.filters.collection,
+    sortBy: state.sortOrder,
+    limit: Search.TAGS_PER_QUERY,
+    offset: start,
+    query: cleanQuery,
+    requireSheetMusic: state.filters.sheetMusic,
+    requireLearningTracks: state.filters.learningTracks,
+    parts: PARTS_PARAMS[state.filters.parts],
   }
-  if (state.filters.sheetMusic) {
-    params.SheetMusic = "Yes"
-  }
-  if (state.filters.learningTracks) {
-    params.Learning = "Yes"
-  }
-  if (state.filters.parts && state.filters.parts !== Parts.any) {
-    params.Parts = PARTS_PARAMS[state.filters.parts]
-  }
-  return params
 }
 
 export async function fetchAndConvertTags(
-  queryParams: QueryParams,
+  searchParams: SearchParams,
+  useApi: boolean,
   baseUrl: string = Search.API_BASE,
 ): Promise<ConvertedTags> {
-  const responseText = await getUrl(baseUrl, {params: queryParams})
-  return convertTags(responseText)
+  if (useApi) {
+    const queryParams = buildApiQueryParams(searchParams)
+    const responseText = await getUrl(baseUrl, {params: queryParams})
+    return tagsFromApiResponse(responseText)
+  } else {
+    return searchDb(searchParams)
+  }
+}
+
+export type ApiQueryParams = {
+  q?: string
+  start?: number
+  id?: number
+  n?: number
+  Collection?: string
+  Sortby?: string
+  SheetMusic?: string
+  Learning?: string
+  Parts?: number
+}
+
+/** This is *kinda* like Kotlin's `.apply`/`.let`, useful for transforming maybe null values in arbitrary ways */
+function apply<T, R>(
+  value: T | undefined,
+  transformer: (value: T) => R,
+): R | undefined {
+  return value === undefined ? undefined : transformer(value)
+}
+
+function buildApiQueryParams(searchParams: SearchParams): ApiQueryParams {
+  return {
+    q: searchParams.query,
+    // API uses 1-based indexing
+    start: apply(searchParams.offset, offset => offset + 1),
+    id: searchParams.id,
+    n: searchParams.limit,
+    Collection: apply(
+      searchParams.collection,
+      collection => COLLECTION_PARAMS[collection],
+    ),
+    Sortby: apply(searchParams.sortBy, sortBy => SORTBY_PARAMS[sortBy]),
+    SheetMusic: searchParams.requireSheetMusic ? "Yes" : undefined,
+    Learning: searchParams.requireLearningTracks ? "Yes" : undefined,
+    Parts: searchParams.parts,
+  }
+}
+
+export type DbRow = {[column: string]: any}
+
+const DEBUG_DB_PERF = false
+function debugDbPerfCurrentTime() {
+  if (DEBUG_DB_PERF) {
+    return global.performance.now()
+  } else {
+    return 0
+  }
+}
+function debugDbPerfLogging(label: string, start: number) {
+  if (DEBUG_DB_PERF) {
+    console.debug(label, debugDbPerfCurrentTime() - start)
+  }
+}
+
+async function searchDb(searchParams: SearchParams): Promise<ConvertedTags> {
+  const overallStart = debugDbPerfCurrentTime()
+  const {whereVariables, whereClause, suffixClauses, suffixVariables} =
+    buildSqlParts(searchParams)
+  const db = await getDbConnection()
+  debugDbPerfLogging("Got db", overallStart)
+
+  // This is kinda a gross API. We can't return anything out of the transaction (and it's generally recommended to use
+  // a transaction), so we have to declare these variables here and mutate them within the transaction function >.>
+  let tagRows: DbRow[] = []
+  let trackRows: DbRow[] = []
+  let videoRows: DbRow[] = []
+  let count = "0"
+
+  await db.runTransactionAsync(async txn => {
+    const start = debugDbPerfCurrentTime()
+    debugDbPerfLogging("Txn start", overallStart)
+    tagRows = (
+      await txn.executeSqlAsync(
+        `SELECT * FROM tags${whereClause}${suffixClauses}`,
+        [...whereVariables, ...suffixVariables],
+      )
+    ).rows
+    const tagTime = debugDbPerfCurrentTime()
+
+    trackRows = (
+      await txn.executeSqlAsync(
+        `SELECT * FROM tracks WHERE tracks.tag_id IN (SELECT id FROM tags${whereClause}${suffixClauses})`,
+        [...whereVariables, ...suffixVariables],
+      )
+    ).rows
+    const trackTime = debugDbPerfCurrentTime()
+
+    videoRows = (
+      await txn.executeSqlAsync(
+        `SELECT * FROM videos WHERE videos.tag_id IN (SELECT id FROM tags${whereClause}${suffixClauses})`,
+        [...whereVariables, ...suffixVariables],
+      )
+    ).rows
+    const videoTime = debugDbPerfCurrentTime()
+
+    const count_raw = await txn.executeSqlAsync(
+      `SELECT COUNT(*) AS count FROM tags${whereClause}`,
+      whereVariables,
+    )
+    const countTime = debugDbPerfCurrentTime()
+    if (DEBUG_DB_PERF) {
+      console.debug(
+        "Per-execution times:",
+        tagTime - start,
+        trackTime - tagTime,
+        videoTime - trackTime,
+        countTime - videoTime,
+        countTime - start,
+      )
+    }
+    count = count_raw.rows[0].count
+  }, true /* readOnly txn */)
+
+  debugDbPerfLogging("Db done, parsing rows", overallStart)
+  return tagsFromDbRows(
+    tagRows,
+    trackRows,
+    videoRows,
+    count,
+    searchParams.offset || 0,
+  )
+}
+
+/**
+ * Given search params, constructs the where clauses+variables (" WHERE ...") and the suffix
+ * clauses+variables (order, limit, offset).
+ */
+function buildSqlParts(searchParams: SearchParams) {
+  let whereClauseParts = []
+  let whereVariables = []
+
+  if (searchParams.id !== undefined) {
+    whereClauseParts.push("tags.id = ?")
+    whereVariables.push(searchParams.id)
+  }
+  if (searchParams.query !== undefined && searchParams.query !== "") {
+    whereClauseParts.push(
+      "tags.id IN (SELECT rowid FROM tags_fts WHERE tags_fts MATCH ?)",
+    )
+    whereVariables.push(searchParams.query)
+  }
+  if (searchParams.parts !== undefined) {
+    whereClauseParts.push("tags.parts = ?")
+    whereVariables.push(searchParams.parts)
+  }
+  if (
+    searchParams.collection !== undefined &&
+    searchParams.collection !== Collection.ALL
+  ) {
+    whereClauseParts.push("tags.collection = ?")
+    whereVariables.push(COLLECTION_PARAMS[searchParams.collection])
+  }
+  if (searchParams.requireLearningTracks) {
+    whereClauseParts.push("tags.id IN (SELECT tag_id FROM tracks)")
+  }
+  if (searchParams.requireSheetMusic) {
+    whereClauseParts.push(
+      "tags.sheet_music_alt IS NOT NULL AND tags.sheet_music_alt != ''",
+    )
+  }
+  let whereClause =
+    whereClauseParts.length === 0
+      ? ""
+      : ` WHERE ${whereClauseParts.join(" AND ")}`
+
+  let suffixClauses = ""
+  let suffixVariables = []
+
+  switch (searchParams.sortBy) {
+    case SortOrder.alpha:
+      suffixClauses += " ORDER BY tags.title ASC"
+      break
+    case SortOrder.downloads:
+      suffixClauses += " ORDER BY tags.downloaded DESC"
+      break
+    case SortOrder.newest:
+      suffixClauses += " ORDER BY tags.posted DESC"
+      break
+  }
+  if (searchParams.limit !== undefined) {
+    suffixClauses += " LIMIT ?"
+    suffixVariables.push(searchParams.limit)
+  }
+  if (searchParams.offset !== undefined) {
+    suffixClauses += " OFFSET ?"
+    suffixVariables.push(searchParams.offset)
+  }
+  return {whereClause, whereVariables, suffixClauses, suffixVariables}
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,10 @@
+import {Mode} from "@app/constants/Search"
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import {AnyAction, configureStore} from "@reduxjs/toolkit"
+import _ from "lodash"
 import {combineReducers} from "redux"
-import {persistReducer, persistStore} from "redux-persist"
+import type {MigrationManifest} from "redux-persist"
+import {createMigrate, persistReducer, persistStore} from "redux-persist"
 import autoMergeLevel2 from "redux-persist/es/stateReconciler/autoMergeLevel2"
 import favoritesReducer from "./modules/favoritesSlice"
 import historyReducer from "./modules/historySlice"
@@ -23,11 +26,21 @@ const rootReducer = combineReducers({
 
 export type AppState = ReturnType<typeof rootReducer>
 
+const MIGRATIONS = {
+  0: (state: AppState) => {
+    state.search.filters.mode = Mode.OFFLINE
+    return state
+  },
+}
+
 const persistConfig = {
   timeout: 10000,
   key: "root",
   storage: AsyncStorage,
   stateReconciler: autoMergeLevel2,
+  version: _.max(Object.keys(MIGRATIONS).map(parseInt)) ?? -1,
+  // The types for `createMigrate` seem just quite wrong, in particular the migration function arg/return type
+  migrate: createMigrate(MIGRATIONS as unknown as MigrationManifest),
 }
 
 const persistedReducer = persistReducer<AppState, AnyAction>(

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,3 @@
-import {Mode} from "@app/constants/Search"
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import {AnyAction, configureStore} from "@reduxjs/toolkit"
 import _ from "lodash"
@@ -28,7 +27,11 @@ export type AppState = ReturnType<typeof rootReducer>
 
 const MIGRATIONS = {
   0: (state: AppState) => {
-    state.search.filters.mode = Mode.OFFLINE
+    state.search.filters.mode = "OFFLINE"
+    return state
+  },
+  1: (state: AppState) => {
+    state.search.filters.offline = true
     return state
   },
 }
@@ -38,10 +41,13 @@ const persistConfig = {
   key: "root",
   storage: AsyncStorage,
   stateReconciler: autoMergeLevel2,
-  version: _.max(Object.keys(MIGRATIONS).map(parseInt)) ?? -1,
+  // for some reason ` version: _.max(Object.keys(MIGRATIONS).map(parseInt)) ?? -1` always ends up as 0
+  version: parseInt(_.max(Object.keys(MIGRATIONS)) ?? "-1", 10),
   // The types for `createMigrate` seem just quite wrong, in particular the migration function arg/return type
   migrate: createMigrate(MIGRATIONS as unknown as MigrationManifest),
 }
+
+console.log(`persistConfig.version=${persistConfig.version}`)
 
 const persistedReducer = persistReducer<AppState, AnyAction>(
   persistConfig,


### PR DESCRIPTION
This is the third phase in modifying goodtags for ~instant offline search. To recap, at a high level, the cumulative set of changes will look like:
1. Have something that periodically snapshots the canonical barbershoptags.com database into a SQL database suitable for use by the app and host that where the app can download it (https://github.com/kamatsuoka/goodtags/pull/7).
2. Update the app to include the latest (at the time) database when compiling it and fetch the latest database on startup, only downloading it if it's actually newer than what the app already has (https://github.com/kamatsuoka/goodtags/pull/9).
3. Update the app to add a parallel code path to direct searches to the database rather than the API (**this PR**).
4. Once this has been validated, rip out the old code path and solely rely on the local database for searches.

This PR adds a new box in the search dialog which allows selection of "mode" as either "offline" (default) or "online" and includes a button for a dialog that describes the difference a bit more. That setting feeds into the actual fetch utilities which will either take the existing code path if "online" is selected, or a brand new code path that hits the local SQLite database if "offline" is selected. 

<details>
<summary>This new selection box and dialog can be seen here:</summary>

| Selection box | Dialog |
| - | - |
| ![offline search mode selection](https://github.com/kamatsuoka/goodtags/assets/463696/a53118bb-fbee-4654-a9ac-61ee3e700d3d) | ![offline search dialog](https://github.com/kamatsuoka/goodtags/assets/463696/e241cc16-677e-47b5-8f6b-c820602a1838) |

</details>

Since we're adding a new field to a persisted store that we want to default to a non-`undefined` value, this adds a migrations system for the persisted store following `redux-persist`'s guide at https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md. Note that the `InitialFilters` value is only relevant when there isn't any existing persisted store.

This makes a few changes to the internal search interface to unify how we interact with the API and the local DB. The search parameters are no longer given as the API expects them but rather using something that more closely resembles their semantic meaning; the translation to the API's query parameters is pushed one layer deeper. Similarly, the app now works on a 0-indexed system rather than the API's 1-indexed results. There are parallel functions for translating the database query results into tag objects, and while there's some duplication currently, the idea is to eventually remove the API/xml ones, so I didn't think it was worth trying to unify them.

Behavior-wise, the DB results are quite similar to the API's, though there are a few known changes:
- It's only searching for whole tokens, so searching for "ebb" will give "Ebb Tide" as expected, but not "Moonlight in Vermont" (which is contributed by "W**ebb** comfort")
- Since the tag ID is included in the set of tokens being searched, we don't do the ID special casing when searching locally, so looking for "1776" now turns up both the tag #1776 ("I Get The Blues Most Every Night") *and* the actual "1776" tag (#922).

This has been mostly tested manually. I've compared the results between this version of the app and the version that's currently live on the Play Store and have been using this offline version of the app for a few weeks. However I haven't written any automated tests since I'm not sure if I can get `expo-sqlite` working within Jest and Detox isn't currently an option.