### PR TITLE
Finish strict mypy checking, check Python types and formatting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,14 @@ on:
 
 jobs:
 
-  test:
-    strategy:
-      fail-fast: true
+  test-js:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*        
+          node-version: lts/*
           cache: yarn
       - name: install typescript dependencies
         shell: bash
@@ -36,3 +34,25 @@ jobs:
         shell: bash
         run: |
           yarn run eslint src
+
+  test-py:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repo'
+        uses: 'actions/checkout@v4'
+      - name: 'set up python'
+        # This is the version of the action for setting up Python, not the Python version.
+        uses: 'actions/setup-python@v4'
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: 'install pip dependencies'
+        run: |
+          python -m pip install --upgrade pip==24.0
+          pip install -r scripts/requirements.txt
+      - name: 'check types'
+        run: |
+          python -m mypy --strict scripts/fetch_search_database.py
+      - name: 'check formatting'
+        run: |
+          python -m black --check --diff scripts/fetch_search_database.py

--- a/scripts/fetch_search_database.py
+++ b/scripts/fetch_search_database.py
@@ -4,11 +4,11 @@ import sqlite3
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Sequence, Mapping
 
-import click  # type: ignore
-import requests  # type: ignore
-import xmltodict  # type: ignore
+import click
+import requests
+import xmltodict
 
 API_URL = "https://www.barbershoptags.com/api.php"
 OUT_DIR = Path(__file__).resolve().parent.parent / "out"
@@ -27,7 +27,7 @@ PAGE_SIZE = 100
 SCHEMA_VERSION = 1
 
 
-def fetch_xml_batches() -> list[dict[str, Any]]:
+def fetch_xml_batches() -> Sequence[Mapping[str, Any]]:
     print("About to start fetching batches")
     batches = []
     i = 0
@@ -78,7 +78,9 @@ ROW_DEFAULTS = {
 }
 
 
-def parse_batches_to_tags(batches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def parse_batches_to_tags(
+    batches: Sequence[Mapping[str, Any]]
+) -> Sequence[Mapping[str, Any]]:
     return [ROW_DEFAULTS | t for batch in batches for t in batch["tags"]["tag"]]
 
 
@@ -110,7 +112,7 @@ PART_NAMES = [
 ]
 
 
-def generate_sql_db(tags: list[dict[str, Any]], out_dir: Path) -> None:
+def generate_sql_db(tags: Sequence[Mapping[str, Any]], out_dir: Path) -> None:
     sql_path = out_dir / SQL_NAME
     sql_path.unlink(missing_ok=True)
     db = sqlite3.connect(sql_path)
@@ -320,7 +322,7 @@ def deploy_to_gh_pages(out_dir: Path) -> None:
 
 
 # Note - If we need them, we can add options for whether to deploy, where to store output
-@click.command()  # type: ignore
+@click.command()
 def main() -> None:
     """
     Job to fetch an up-to-date copy of the tags database, in batches of 100 rows, and write the result to a SQL

--- a/scripts/requirements.in
+++ b/scripts/requirements.in
@@ -2,4 +2,10 @@
 click
 requests
 xmltodict
+
+# Tools for development
+black
+mypy
 pip-tools
+types-requests
+types-xmltodict

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,16 +4,24 @@
 #
 #    pip-compile --no-annotate ./scripts/requirements.in
 #
+black==24.4.0
 build==1.1.1
 certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
 colorama==0.4.6
 idna==3.6
+mypy==1.9.0
+mypy-extensions==1.0.0
 packaging==24.0
+pathspec==0.12.1
 pip-tools==7.4.1
+platformdirs==4.2.0
 pyproject-hooks==1.0.0
 requests==2.31.0
+types-requests==2.31.0.20240406
+types-xmltodict==0.13.0.3
+typing-extensions==4.11.0
 urllib3==2.2.1
 wheel==0.43.0
 xmltodict==0.13.0


### PR DESCRIPTION
This finishes adding strict mypy type checking, including getting rid of `type: ignore`s by adding the relevant type stub packages. It also adds checks for Python types and formatting in CI.